### PR TITLE
Fix for #10 and #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .packages
 build/
 pubspec.lock
+.flutter-plugins
+.flutter-plugins-dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2022-03-14
+
+### Changed
+
+- `ModelViewer`'s default `backgroundColor` from `Colors.white` to `Colors.transparent`, due to [#12](https://github.com/omchiii/model_viewer_plus.dart/issues/12)
+- `proxy`'s null check fix and `setState() {}` for it, due to [#10](https://github.com/omchiii/model_viewer_plus.dart/issues/10)
+
 ## [1.1.2] - 2022-02-17
 
 ### Added

--- a/lib/src/html_builder.dart
+++ b/lib/src/html_builder.dart
@@ -10,7 +10,7 @@ abstract class HTMLBuilder {
   static String build(
       {final String htmlTemplate = '',
       required final String src,
-      final Color backgroundColor = const Color(0xFFFFFF),
+      final Color backgroundColor = Colors.transparent,
       final String? alt,
       final bool? ar,
       final List<String>? arModes,
@@ -24,7 +24,7 @@ abstract class HTMLBuilder {
     html.write('<model-viewer');
     html.write(' src="${htmlEscape.convert(src)}"');
     html.write(
-        ' style="background-color: rgb(${backgroundColor.red}, ${backgroundColor.green}, ${backgroundColor.blue});"');
+        ' style="background-color: rgba(${backgroundColor.red}, ${backgroundColor.green}, ${backgroundColor.blue}, ${backgroundColor.alpha});"');
     if (alt != null) {
       html.write(' alt="${htmlEscape.convert(alt)}"');
     }

--- a/lib/src/model_viewer_plus.dart
+++ b/lib/src/model_viewer_plus.dart
@@ -8,7 +8,7 @@ import 'model_viewer_plus_stub.dart'
 class ModelViewer extends StatefulWidget {
   ModelViewer(
       {Key? key,
-      this.backgroundColor = Colors.white,
+      this.backgroundColor = Colors.transparent,
       required this.src,
       this.alt,
       this.ar,
@@ -23,7 +23,7 @@ class ModelViewer extends StatefulWidget {
 
   /// The background color for the model viewer.
   ///
-  /// The theme's [ThemeData.scaffoldBackgroundColor] by default.
+  /// [Colors.transparent] by default.
   final Color backgroundColor;
 
   /// The URL or path to the 3D model. This parameter is required.

--- a/lib/src/model_viewer_plus_mobile.dart
+++ b/lib/src/model_viewer_plus_mobile.dart
@@ -46,7 +46,14 @@ class ModelViewerState extends State<ModelViewer> {
   @override
   Widget build(final BuildContext context) {
     if (_proxy == null) {
+      return Center(
+        child: CircularProgressIndicator(
+          semanticsLabel: 'Loading Model Viewer...',
+        ),
+      );
+    } else {
       return WebView(
+        backgroundColor: Colors.transparent,
         initialUrl: null,
         javascriptMode: JavascriptMode.unrestricted,
         initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
@@ -97,11 +104,6 @@ class ModelViewerState extends State<ModelViewer> {
               '>>>> ModelViewer failed to load: ${error.description} (${error.errorType} ${error.errorCode})'); // DEBUG
         },
       );
-    } else {
-      return Center(
-          child: CircularProgressIndicator(
-        semanticsLabel: 'Loading Model Viewer...',
-      ));
     }
   }
 
@@ -125,6 +127,11 @@ class ModelViewerState extends State<ModelViewer> {
   Future<void> _initProxy() async {
     final url = Uri.parse(widget.src);
     _proxy = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+
+    setState(() {
+      _proxy;
+    });
+
     _proxy!.listen((final HttpRequest request) async {
       //print("${request.method} ${request.uri}"); // DEBUG
       //print(request.headers); // DEBUG

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 # See: https://dart.dev/tools/pub/pubspec
 name: model_viewer_plus
-version: 1.1.2
+version: 1.1.3
 description: >-
   A Flutter widget for rendering interactive 3D models in the glTF and GLB
   formats.


### PR DESCRIPTION
Changed:

- `ModelViewer`'s default `backgroundColor` from `Colors.white` to `Colors.transparent`, due to [#12](https://github.com/omchiii/model_viewer_plus.dart/issues/12)
- `proxy`'s null check fix and `setState() {}` for it, due to [#10](https://github.com/omchiii/model_viewer_plus.dart/issues/10)