### PR TITLE
Fix #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2022-03-14
+
+### Changed
+
+- `/lib/src/model_viewer_plus_mobile.dart`, update according to the [newest document](https://developers.google.com/ar/develop/scene-viewer#3d-or-ar). Fix [#9](https://github.com/omchiii/model_viewer_plus.dart/issues/9).
+  - Insted of `com.google.ar.core`, now we use `com.google.android.googlequicksearchbox`. This should support the widest possible range of devices.
+  - Mode defaults to `ar_preferred`. Scene Viewer launches in AR native mode as the entry mode. If Google Play Services for AR isn't present, Scene Viewer gracefully falls back to 3D mode as the entry mode.
+- Add `arModes` to example, closer to [modelviewer.dev](https://modelviewer.dev)'s offical example.
+- Update `example\android\app\build.gradle` `compileSdkVersion` to 31
+- Update `android_intent_plus` to `3.1.1`
+- Update `android_intent_plus to` `3.0.1`
+
+### Removed
+
+- `/lib/src/http_proxy.dart`: empty file
+
 ## [1.1.3] - 2022-03-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ web component in a [WebView](https://pub.dev/packages/webview_flutter).
 
 Android, iOS, Web, with [a recent system browser version](https://modelviewer.dev/#section-browser-support).
 
+## Notes
+
+We use the [Google APP](https://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox), `com.google.android.googlequicksearchbox` to display interactive 3D models on Android. The model displays in 'ar_preferred' mode by default, Scene Viewer launches in AR native mode as the entry mode. If [Google Play Services for AR (ARCore, `com.google.ar.core`)](https://play.google.com/store/apps/details?id=com.google.ar.core) isn't present, Scene Viewer gracefully falls back to 3D mode as the entry mode.
+
 ## Installation
 
 ### `pubspec.yaml`
 
 ```yaml
 dependencies:
-   model_viewer_plus: ^1.0.0
+   model_viewer_plus: ^(newest from https://pub.dev/packages/model_viewer_plus)
 ```
 
 ### `AndroidManifest.xml` (Android 9+ only)

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     lintOptions {
         disable 'InvalidPackage'

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,10 +13,11 @@ class MyApp extends StatelessWidget {
         appBar: AppBar(title: Text("Model Viewer")),
         body: ModelViewer(
           backgroundColor: Color.fromARGB(0xFF, 0xEE, 0xEE, 0xEE),
-          //src: 'https://modelviewer.dev/shared-assets/models/Astronaut.glb',
+          // src: 'https://modelviewer.dev/shared-assets/models/Astronaut.glb',
           src: 'assets/Astronaut.glb', // a bundled asset file
           alt: "A 3D model of an astronaut",
           ar: true,
+          arModes: ['scene-viewer', 'webxr', 'quick-look'],
           autoRotate: true,
           cameraControls: true,
         ),

--- a/lib/src/html_builder.dart
+++ b/lib/src/html_builder.dart
@@ -75,6 +75,9 @@ abstract class HTMLBuilder {
     // TODO: shadow-intensity
     // TODO: shadow-softness
     html.writeln('></model-viewer>');
+
+    // print(html.toString()); // DEBUG
+
     return html.toString();
   }
 }

--- a/lib/src/http_proxy.dart
+++ b/lib/src/http_proxy.dart
@@ -1,1 +1,0 @@
-/* This is free and unencumbered software released into the public domain. */

--- a/lib/src/model_viewer_plus_web.dart
+++ b/lib/src/model_viewer_plus_web.dart
@@ -5,10 +5,8 @@ import 'package:flutter/services.dart' show rootBundle;
 
 import 'html_builder.dart';
 
-// import 'dart:ui' as ui;
 import 'shim/dart_ui_fake.dart' if (dart.library.html) 'dart:ui' as ui;
 import 'shim/dart_html_fake.dart' if (dart.library.html) 'dart:html';
-// import 'dart:html';
 
 import 'model_viewer_plus.dart';
 
@@ -39,7 +37,6 @@ class ModelViewerState extends State<ModelViewer> {
             // Loading Attributes
             'src',
             'alt',
-            'poster',
             'poster',
             'seamless-poster',
             'loading',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 # See: https://dart.dev/tools/pub/pubspec
 name: model_viewer_plus
-version: 1.1.3
+version: 1.1.4
 description: >-
   A Flutter widget for rendering interactive 3D models in the glTF and GLB
   formats.
@@ -14,8 +14,8 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  android_intent_plus: ^3.0.2
-  webview_flutter: ^3.0.0
+  android_intent_plus: ^3.1.1
+  webview_flutter: ^3.0.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### Changed

- `/lib/src/model_viewer_plus_mobile.dart`, update according to the [newest document](https://developers.google.com/ar/develop/scene-viewer#3d-or-ar). Fix [#9](https://github.com/omchiii/model_viewer_plus.dart/issues/9).
  - Insted of `com.google.ar.core`, now we use `com.google.android.googlequicksearchbox`. This should support the widest possible range of devices.
  - Mode defaults to `ar_preferred`. Scene Viewer launches in AR native mode as the entry mode. If Google Play Services for AR isn't present, Scene Viewer gracefully falls back to 3D mode as the entry mode.
- Update `example\android\app\build.gradle` `compileSdkVersion` to 31
- Update `android_intent_plus` to `3.1.1`
- Update `android_intent_plus to` `3.0.1`

### Removed

- `/lib/src/http_proxy.dart`: empty file

