### PR TITLE
[web] Add button with hotspot attributes to allowed elements

### DIFF
--- a/lib/src/model_viewer_plus_web.dart
+++ b/lib/src/model_viewer_plus_web.dart
@@ -42,6 +42,17 @@ class ModelViewerState extends State<ModelViewer> {
             'referrerpolicy'
           ],
           uriPolicy: _AllowUriPolicy())
+      ..allowElement('button',
+          attributes: [
+            'class',
+            'slot',
+            'data-position',
+            'data-normal',
+            'data-orbit',
+            'data-target',
+            'data-visibility-attribute'
+          ],
+          uriPolicy: _AllowUriPolicy())
       ..allowCustomElement('model-viewer',
           attributes: [
             'style',


### PR DESCRIPTION
Annotations feature ([documentation](https://modelviewer.dev/examples/annotations/index.html)) is not yet supported on web due to NodeValidator removing button tag from innerHTML. This solves the issue.