### PR TITLE
Allowing customize NodeValidator on Web platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2023-01-13
+
+### Removed
+
+- **BREAKING** [#49 Add button with hotspot attributes to allowed elements](https://github.com/omchiii/model_viewer_plus.dart/pull/49), because you can customize them now.
+
+### Added
+
+- Allowing customize NodeValidator on Web platform by using `overwriteNodeValidatorBuilder`.
+- New example, `example\lib\materials_and_scene\change_color.dart`
+
+### Fixed
+
+- lints
+- Upgrade Dart SDK in the example folder to 2.12.0 to "Running with sound null safety"
+
 ## [1.4.0] - 2022-12-06
 
 ### Changed
@@ -13,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples support Android API 33
 - Dependencies upgrade
 
-## 2022-10-08
+## [] - 2022-10-08
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ web component in a [WebView](https://pub.dev/packages/webview_flutter).
 
 ## Compatibility
 
-Android, iOS, Web, with [a recent system browser version](https://modelviewer.dev/#section-browser-support).
+- Android
+- iOS (AR View may not avaliable on iOS 16+)
+- Web, with [a recent system browser version](https://modelviewer.dev/#section-browser-support).
 
 ## Notes
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,6 @@
 # See: https://dart.dev/guides/language/analysis-options
 ---
-include: package:pedantic/analysis_options.1.9.0.yaml
+include: package:lints/recommended.yaml
 analyzer:
   exclude:
     - example/**.dart

--- a/example/lib/materials_and_scene/change_color.dart
+++ b/example/lib/materials_and_scene/change_color.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:model_viewer_plus/model_viewer_plus.dart';
+
+import 'package:model_viewer_plus/src/model_viewer_plus_web.dart';
+import 'package:model_viewer_plus/src/shim/dart_html_fake.dart'
+    if (dart.library.html) 'dart:html';
+
+void main() => runApp(MyApp());
+
+String js = r'''
+const modelViewerColor = document.querySelector("model-viewer#color");
+
+document.querySelector('#color-controls').addEventListener('click', (event) => {
+  const colorString = event.target.dataset.color;
+  const [material] = modelViewerColor.model.materials;
+  material.pbrMetallicRoughness.setBaseColorFactor(colorString);
+});
+
+''';
+
+String html = r'''
+  <div class="controls" id="color-controls">
+    <button data-color="#ff0000">Red</button>
+    <button data-color="#00ff00">Green</button>
+    <button data-color="#0000ff">Blue</button>
+  </div>
+''';
+
+NodeValidatorBuilder myNodeValidatorBuilder = defaultNodeValidatorBuilder
+  ..allowElement('button',
+      attributes: ['data-color'], uriPolicy: AllowAllUri());
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: Text("Model Viewer")),
+        body: ModelViewer(
+          id: "color",
+          src: 'https://modelviewer.dev/shared-assets/models/Astronaut.glb',
+          alt: "A 3D model of an astronaut",
+          touchAction: TouchAction.panY,
+          ar: true,
+          orientation: "20deg 0 0",
+          cameraControls: true,
+          relatedJs: js,
+          innerModelViewerHtml: html,
+          overwriteNodeValidatorBuilder: myNodeValidatorBuilder,
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,8 +14,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^2.0.1
 environment:
-  sdk: '>=2.8.1 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 flutter:
   uses-material-design: true
   assets:

--- a/lib/src/html_builder.dart
+++ b/lib/src/html_builder.dart
@@ -201,7 +201,7 @@ abstract class HTMLBuilder {
     }
     // orbit-sensitivity
     if (orbitSensitivity != null) {
-      modelViewerHtml.write(' orbit-sensitivity="${orbitSensitivity}"');
+      modelViewerHtml.write(' orbit-sensitivity="$orbitSensitivity"');
     }
     // auto-rotate
     if (autoRotate ?? false) {

--- a/lib/src/model_viewer_plus_mobile.dart
+++ b/lib/src/model_viewer_plus_mobile.dart
@@ -306,7 +306,7 @@ class ModelViewerState extends State<ModelViewer> {
               ...pathSegments,
               request.uri.path.replaceFirst('/', '')
             ]);
-            debugPrint("Try: ${tryDestination}");
+            debugPrint("Try: $tryDestination");
             await response.redirect(Uri.parse(tryDestination));
           } else {
             debugPrint('404 with ${request.uri}');

--- a/lib/src/model_viewer_plus_web.dart
+++ b/lib/src/model_viewer_plus_web.dart
@@ -24,95 +24,10 @@ class ModelViewerState extends State<ModelViewer> {
   void generateModelViewerHtml() async {
     final htmlTemplate = await rootBundle
         .loadString('packages/model_viewer_plus/assets/template.html');
+
     // allow to use elements
-    final NodeValidator _validator = NodeValidatorBuilder.common()
-      ..allowElement('meta',
-          attributes: ['name', 'content'], uriPolicy: _AllowUriPolicy())
-      ..allowElement('style')
-      ..allowElement('script',
-          attributes: [
-            'src',
-            'type',
-            'defer',
-            'async',
-            'crossorigin',
-            'integrity',
-            'nomodule',
-            'nonce',
-            'referrerpolicy'
-          ],
-          uriPolicy: _AllowUriPolicy())
-      ..allowElement('button',
-          attributes: [
-            'class',
-            'slot',
-            'data-position',
-            'data-normal',
-            'data-orbit',
-            'data-target',
-            'data-visibility-attribute'
-          ],
-          uriPolicy: _AllowUriPolicy())
-      ..allowCustomElement('model-viewer',
-          attributes: [
-            'style',
-
-            // Loading Attributes
-            'src',
-            'alt',
-            'poster',
-            'loading',
-            'reveal',
-            'with-credentials',
-
-            // Augmented Reality Attributes
-            'ar',
-            'ar-modes',
-            'ar-scale',
-            'ar-placement',
-            'ios-src',
-            'xr-environment',
-
-            // Staing & Cameras Attributes
-            'camera-controls',
-            'disable-pan',
-            'disable-tap',
-            'touch-action',
-            'disable-zoom',
-            'orbit-sensitivity',
-            'auto-rotate',
-            'auto-rotate-delay',
-            'rotation-per-second',
-            'interaction-prompt',
-            'interaction-prompt-style',
-            'interaction-prompt-threshold',
-            'camera-orbit',
-            'camera-target',
-            'field-of-view',
-            'max-camera-orbit',
-            'min-camera-orbit',
-            'max-field-of-view',
-            'min-field-of-view',
-            'interpolation-decay',
-
-            // Lighting & Env Attributes
-            'skybox-image',
-            'environment-image',
-            'exposure',
-            'shadow-intensity',
-            'shadow-softness ',
-
-            // Animation Attributes
-            'animation-name',
-            'animation-crossfade-duration',
-            'autoplay',
-
-            // Materials & Scene Attributes
-            'variant-name',
-            'orientation',
-            'scale',
-          ],
-          uriPolicy: _AllowUriPolicy());
+    final NodeValidator _validator =
+        widget.overwriteNodeValidatorBuilder ?? defaultNodeValidatorBuilder;
 
     final html = _buildHTML(htmlTemplate);
 
@@ -229,7 +144,85 @@ class ModelViewerState extends State<ModelViewer> {
   }
 }
 
-class _AllowUriPolicy implements UriPolicy {
+NodeValidatorBuilder defaultNodeValidatorBuilder = NodeValidatorBuilder.common()
+  ..allowElement('meta',
+      attributes: ['name', 'content'], uriPolicy: AllowAllUri())
+  ..allowElement('style')
+  ..allowElement('script',
+      attributes: [
+        'src',
+        'type',
+        'defer',
+        'async',
+        'crossorigin',
+        'integrity',
+        'nomodule',
+        'nonce',
+        'referrerpolicy'
+      ],
+      uriPolicy: AllowAllUri())
+  ..allowCustomElement('model-viewer',
+      attributes: [
+        'style',
+
+        // Loading Attributes
+        'src',
+        'alt',
+        'poster',
+        'loading',
+        'reveal',
+        'with-credentials',
+
+        // Augmented Reality Attributes
+        'ar',
+        'ar-modes',
+        'ar-scale',
+        'ar-placement',
+        'ios-src',
+        'xr-environment',
+
+        // Staing & Cameras Attributes
+        'camera-controls',
+        'disable-pan',
+        'disable-tap',
+        'touch-action',
+        'disable-zoom',
+        'orbit-sensitivity',
+        'auto-rotate',
+        'auto-rotate-delay',
+        'rotation-per-second',
+        'interaction-prompt',
+        'interaction-prompt-style',
+        'interaction-prompt-threshold',
+        'camera-orbit',
+        'camera-target',
+        'field-of-view',
+        'max-camera-orbit',
+        'min-camera-orbit',
+        'max-field-of-view',
+        'min-field-of-view',
+        'interpolation-decay',
+
+        // Lighting & Env Attributes
+        'skybox-image',
+        'environment-image',
+        'exposure',
+        'shadow-intensity',
+        'shadow-softness ',
+
+        // Animation Attributes
+        'animation-name',
+        'animation-crossfade-duration',
+        'autoplay',
+
+        // Materials & Scene Attributes
+        'variant-name',
+        'orientation',
+        'scale',
+      ],
+      uriPolicy: AllowAllUri());
+
+class AllowAllUri implements UriPolicy {
   @override
   bool allowsUri(String uri) {
     return true;

--- a/lib/src/shim/dart_html_fake.dart
+++ b/lib/src/shim/dart_html_fake.dart
@@ -7,11 +7,46 @@ class HtmlHtmlElement {
   dynamic setInnerHtml(String html, {NodeValidator? validator}) {}
 }
 
-class NodeValidatorBuilder {
-  static dynamic common() {}
+class NodeValidatorBuilder extends NodeValidator {
+  NodeValidatorBuilder.common();
+  void add(NodeValidator validator) {}
+  void allowCustomElement(String tagName,
+      {UriPolicy? uriPolicy,
+      Iterable<String>? attributes,
+      Iterable<String>? uriAttributes}) {}
+  void allowElement(String tagName,
+      {UriPolicy? uriPolicy,
+      Iterable<String>? attributes,
+      Iterable<String>? uriAttributes}) {}
+  void allowHtml5({UriPolicy? uriPolicy}) {}
+  void allowImages([UriPolicy? uriPolicy]) {}
+  void allowInlineStyles({String? tagName}) {}
+  void allowNavigation([UriPolicy? uriPolicy]) {}
+  @override
+  bool allowsAttribute(Element element, String attributeName, String value) {
+    return true;
+  }
+
+  @override
+  bool allowsElement(Element element) {
+    return true;
+  }
+
+  void allowSvg() {}
+  void allowTagExtension(String tagName, String baseName,
+      {UriPolicy? uriPolicy,
+      Iterable<String>? attributes,
+      Iterable<String>? uriAttributes}) {}
+  void allowTemplating() {}
+  void allowTextElements() {}
 }
 
-abstract class NodeValidator {}
+abstract class Element {}
+
+abstract class NodeValidator {
+  bool allowsAttribute(Element element, String attributeName, String value);
+  bool allowsElement(Element element);
+}
 
 abstract class UriPolicy {
   bool allowsUri(String uri);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 # See: https://dart.dev/tools/pub/pubspec
 name: model_viewer_plus
-version: 1.4.0
+version: 1.5.0
 description: >-
   A Flutter widget for rendering interactive 3D models in the glTF and GLB
   formats.


### PR DESCRIPTION
Fix #62 

### Removed

- **BREAKING** [#49 Add button with hotspot attributes to allowed elements](https://github.com/omchiii/model_viewer_plus.dart/pull/49), because you can customize them now.

### Added

- Allowing customize NodeValidator on Web platform by using `overwriteNodeValidatorBuilder`.
- New example, `example\lib\materials_and_scene\change_color.dart`

### Fixed

- lints
- Upgrade Dart SDK in the example folder to 2.12.0 to "Running with sound null safety"

