### PR TITLE
fix: allow optional debug logging

### DIFF
--- a/lib/src/html_builder.dart
+++ b/lib/src/html_builder.dart
@@ -73,6 +73,7 @@ abstract class HTMLBuilder {
     final String? relatedCss,
     final String? relatedJs,
     final String? id,
+    final bool? debugLogging,
   }) {
     if (relatedCss != null) {
       htmlTemplate = htmlTemplate.replaceFirst('/* other-css */', relatedCss);
@@ -399,10 +400,15 @@ abstract class HTMLBuilder {
       modelViewerHtml.writeln('</script>');
     }
 
-    debugPrint("HTML generated for model_viewer_plus:");
+    if (debugLogging == true) {
+      debugPrint("HTML generated for model_viewer_plus:");
+    }
     var html =
         htmlTemplate.replaceFirst('<!-- body -->', modelViewerHtml.toString());
-    debugPrint(html); // DEBUG
+
+    if (debugLogging == true) {
+      debugPrint(html); // DEBUG
+    }
 
     return html;
   }

--- a/lib/src/model_viewer_plus.dart
+++ b/lib/src/model_viewer_plus.dart
@@ -81,6 +81,7 @@ class ModelViewer extends StatefulWidget {
     this.relatedCss,
     this.relatedJs,
     this.id,
+    this.debugLogging = true,
     this.overwriteNodeValidatorBuilder,
     this.javascriptChannels,
     this.onWebViewCreated,
@@ -569,6 +570,11 @@ class ModelViewer extends StatefulWidget {
 
   /// The id of the [ModelViewer] in HTML.
   final String? id;
+
+  /// If false, [HTMLBuilder] will not print debug logs.
+  ///
+  /// Defaults to true;
+  final bool? debugLogging;
 
   /// Customize allowed tags & attrubutes for Web platform.
   ///

--- a/lib/src/model_viewer_plus_mobile.dart
+++ b/lib/src/model_viewer_plus_mobile.dart
@@ -222,6 +222,7 @@ class ModelViewerState extends State<ModelViewer> {
       relatedCss: widget.relatedCss,
       relatedJs: widget.relatedJs,
       id: widget.id,
+      debugLogging: widget.debugLogging,
     );
   }
 

--- a/lib/src/model_viewer_plus_web.dart
+++ b/lib/src/model_viewer_plus_web.dart
@@ -140,6 +140,7 @@ class ModelViewerState extends State<ModelViewer> {
       relatedCss: widget.relatedCss,
       relatedJs: widget.relatedJs,
       id: widget.id,
+      debugLogging: widget.debugLogging,
     );
   }
 }


### PR DESCRIPTION
Provides optional `debugLogging` parameter to `ModelViewer`. When set to `false`, `HTMLBuilder` will not print the debug log of the html.

#64 