### PR TITLE
Allow updating model path on mobile

### DIFF
--- a/lib/src/model_viewer_plus_mobile.dart
+++ b/lib/src/model_viewer_plus_mobile.dart
@@ -220,7 +220,6 @@ class ModelViewerState extends State<ModelViewer> {
   }
 
   Future<void> _initProxy() async {
-    final url = Uri.parse(widget.src);
     _proxy = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
 
     setState(() {
@@ -230,6 +229,7 @@ class ModelViewerState extends State<ModelViewer> {
     });
 
     _proxy!.listen((request) async {
+      final url = Uri.parse(widget.src);
       final response = request.response;
 
       switch (request.uri.path) {


### PR DESCRIPTION
Move url variable into proxy.listen so it loads the updated model if the webview is refreshed. This can be used to update the component if the model ever changes dynamically 