### PR TITLE
Data URI compatibility for src

### DIFF
--- a/lib/src/model_viewer_plus.dart
+++ b/lib/src/model_viewer_plus.dart
@@ -107,6 +107,8 @@ class ModelViewer extends StatefulWidget {
   /// - a relative pathname for Flutter app assets
   ///   (for example, `assets/MyModel.glb`)
   ///
+  /// - a data URI containing the model's data
+  ///
   /// `<model-viewer>` official document: https://modelviewer.dev/docs/#entrydocs-loading-attributes-src
   final String src;
 

--- a/lib/src/model_viewer_plus.dart
+++ b/lib/src/model_viewer_plus.dart
@@ -107,7 +107,7 @@ class ModelViewer extends StatefulWidget {
   /// - a relative pathname for Flutter app assets
   ///   (for example, `assets/MyModel.glb`)
   ///
-  /// - a data URI containing the model's data
+  /// - a `data:` data URI containing the model's data
   ///
   /// `<model-viewer>` official document: https://modelviewer.dev/docs/#entrydocs-loading-attributes-src
   final String src;

--- a/lib/src/model_viewer_plus_mobile.dart
+++ b/lib/src/model_viewer_plus_mobile.dart
@@ -57,9 +57,15 @@ class ModelViewerState extends State<ModelViewer> {
   }
 
   String _buildHTML(String htmlTemplate) {
+    String src;
+    if (widget.src.startsWith('data:')) {
+      src = widget.src;
+    } else {
+      src = '/model';
+    }
     return HTMLBuilder.build(
       htmlTemplate: htmlTemplate,
-      src: '/model',
+      src: src,
       alt: widget.alt,
       poster: widget.poster,
       loading: widget.loading,
@@ -170,7 +176,8 @@ class ModelViewerState extends State<ModelViewer> {
             // );
 
             final String fileURL;
-            if (['http', 'https'].contains(Uri.parse(widget.src).scheme)) {
+            if (['http', 'https', 'data']
+                .contains(Uri.parse(widget.src).scheme)) {
               fileURL = widget.src;
             } else {
               fileURL = p.joinAll([_proxyURL, 'model']);


### PR DESCRIPTION
Explicitly add compatibility for data URI usage in the widget's src.
This would already work in web and desktop but because of the proxy on mobile, it wouldnt work.

Fetch's security enforcement would not allow to follow the redirect (matching /model response case) of the proxy's http scheme to the data scheme.

Since a data URI holds everything, there is no need to go as low as fetching /model to access files or assets only exposed to flutter.